### PR TITLE
Maintain separate metrics per role for Aurora

### DIFF
--- a/src/brad/daemon/monitored_metrics.json
+++ b/src/brad/daemon/monitored_metrics.json
@@ -62,6 +62,7 @@
         },
         {
             "engine": "aurora",
+            "roles": ["WRITER", "READER"],
             "metrics": {
                 "CPUUtilization": [
                     "SampleCount",


### PR DESCRIPTION
Distinguish between the metrics related to Aurora writer instances and those related to read replicas.

Closes #101 