### PR TITLE
Switch to system load metric scaling on Aurora

### DIFF
--- a/config/planner.yml
+++ b/config/planner.yml
@@ -132,10 +132,12 @@ redshift_load_factor:
   min_scaling_cpu: 30
 
 aurora_load_factor:
+  # Proportionality factor for cross-provisioning CPU changes.
   resource_alpha: 1.0
-  # p = [alpha * base * gamma * CPU] + [(1 - gamma) * base]
-  cpu_alpha: 0.04416129
-  cpu_gamma: 1.0
+
+  # Proportionality factor for the load metric's effect on query latency.
+  # p = alpha * base * load
+  load_alpha: 0.53865956
 
   # Legacy factors.
   cpu_to_load_alpha: 0.8761541

--- a/src/brad/config/planner.py
+++ b/src/brad/config/planner.py
@@ -110,11 +110,8 @@ class PlannerConfig:
     def aurora_load_resource_alpha(self) -> float:
         return float(self._raw["aurora_load_factor"]["resource_alpha"])
 
-    def aurora_load_cpu_alpha(self) -> float:
-        return float(self._raw["aurora_load_factor"]["cpu_alpha"])
-
-    def aurora_load_cpu_gamma(self) -> float:
-        return float(self._raw["aurora_load_factor"]["cpu_gamma"])
+    def aurora_load_alpha(self) -> float:
+        return float(self._raw["aurora_load_factor"]["load_alpha"])
 
     # These two are legacy scaling factors.
     def aurora_load_cpu_to_load_alpha(self) -> float:

--- a/src/brad/planner/metrics.py
+++ b/src/brad/planner/metrics.py
@@ -2,7 +2,13 @@ from collections import namedtuple
 from brad.daemon.monitor import Monitor
 
 Metrics = namedtuple(
-    "Metrics", ["redshift_cpu_avg", "aurora_cpu_avg", "buffer_hit_pct_avg"]
+    "Metrics",
+    [
+        "redshift_cpu_avg",
+        "aurora_cpu_avg",
+        "buffer_hit_pct_avg",
+        "aurora_load_minute_avg",
+    ],
 )
 
 
@@ -44,13 +50,14 @@ class MetricsFromMonitor(MetricsProvider):
             )
 
         if metrics.empty:
-            return Metrics(1.0, 1.0, 100.0)
+            return Metrics(1.0, 1.0, 100.0, 1.0)
 
         redshift_cpu = metrics[_RELEVANT_METRICS["redshift_cpu_avg"]].iloc[0]
         aurora_cpu = metrics[_RELEVANT_METRICS["aurora_cpu_avg"]].iloc[0]
         hit_pct = metrics[_RELEVANT_METRICS["buffer_hit_pct_avg"]].iloc[0]
 
-        return Metrics(redshift_cpu, aurora_cpu, hit_pct)
+        # TODO: Retrieve performance insights metrics.
+        return Metrics(redshift_cpu, aurora_cpu, hit_pct, aurora_load_minute_avg=1.0)
 
 
 _RELEVANT_METRICS = {


### PR DESCRIPTION
Part of #175. This PR bases our Aurora system load model on the system load metric (provided by AWS performance insights). This metric is a better choice than CPU utilization because (i) it has no upper limit, and (ii) it is agnostic to the CPU resources available.

We still need to modify the `Monitor` to retrieve performance insights metrics.