### PR TITLE
Move relevant internal command handling to the daemon

### DIFF
--- a/src/brad/daemon/messages.py
+++ b/src/brad/daemon/messages.py
@@ -1,3 +1,4 @@
+from brad.row_list import RowList
 from brad.blueprint import Blueprint
 
 
@@ -18,6 +19,26 @@ class MetricsReport:
     def __init__(self, fe_index: int, txn_completions_per_s: float) -> None:
         self.fe_index = fe_index
         self.txn_completions_per_s = txn_completions_per_s
+
+
+class InternalCommandRequest:
+    """
+    Sent from the front end to the daemon to handle an internal command.
+    """
+
+    def __init__(self, fe_index: int, request: str) -> None:
+        self.fe_index = fe_index
+        self.request = request
+
+
+class InternalCommandResponse:
+    """
+    Sent from the daemon to the front end to respond to an `InternalCommandRequest`.
+    """
+
+    def __init__(self, fe_index: int, response: RowList) -> None:
+        self.fe_index = fe_index
+        self.response = response
 
 
 class ShutdownFrontEnd:

--- a/src/brad/front_end/front_end.py
+++ b/src/brad/front_end/front_end.py
@@ -4,7 +4,7 @@ import logging
 import random
 import time
 import multiprocessing as mp
-from typing import AsyncIterable, Optional, Dict, Any, List, Tuple
+from typing import AsyncIterable, Optional, Dict, Any
 from datetime import datetime, timezone
 
 import grpc
@@ -13,13 +13,24 @@ import pyodbc
 import brad.proto_gen.brad_pb2_grpc as brad_grpc
 
 from brad.asset_manager import AssetManager
+from brad.blueprint_manager import BlueprintManager
 from brad.config.engine import Engine
 from brad.config.file import ConfigFile
 from brad.daemon.monitor import Monitor
-from brad.daemon.messages import ShutdownFrontEnd, Sentinel, MetricsReport
+from brad.daemon.messages import (
+    ShutdownFrontEnd,
+    Sentinel,
+    MetricsReport,
+    InternalCommandRequest,
+    InternalCommandResponse,
+)
 from brad.data_stats.estimator import Estimator
 from brad.data_stats.postgres_estimator import PostgresEstimator
-from brad.data_sync.execution.executor import DataSyncExecutor
+from brad.front_end.brad_interface import BradInterface
+from brad.front_end.epoch_file_handler import EpochFileHandler
+from brad.front_end.errors import QueryError
+from brad.front_end.grpc import BradGrpc
+from brad.front_end.session import SessionManager, SessionId
 from brad.query_rep import QueryRep
 from brad.routing.always_one import AlwaysOneRouter
 from brad.routing.rule_based import RuleBased
@@ -27,20 +38,14 @@ from brad.routing.location_aware_round_robin import LocationAwareRoundRobin
 from brad.routing.policy import RoutingPolicy
 from brad.routing.router import Router
 from brad.routing.tree_based.forest_router import ForestRouter
-from brad.front_end.brad_interface import BradInterface
-from brad.blueprint_manager import BlueprintManager
-from brad.front_end.epoch_file_handler import EpochFileHandler
-from brad.front_end.errors import QueryError
-from brad.front_end.grpc import BradGrpc
-from brad.front_end.session import SessionManager, SessionId
+from brad.row_list import RowList
 from brad.utils.counter import Counter
 from brad.utils.json_decimal_encoder import DecimalEncoder
+from brad.utils.mailbox import Mailbox
 
 logger = logging.getLogger(__name__)
 
 LINESEP = "\n".encode()
-
-RowList = List[Tuple[Any, ...]]
 
 
 class BradFrontEnd(BradInterface):
@@ -125,6 +130,13 @@ class BradFrontEnd(BradInterface):
         # Number of transactions that completed.
         self._transaction_end_counter = Counter()
         self._brad_metrics_reporting_task: Optional[asyncio.Task[None]] = None
+
+        # Used to manage `BRAD_` requests that need to be sent to the daemon for
+        # execution. We only allow one such request to be in flight at any time
+        # (to simplify the logic here, since we only need it for completeness).
+        self._daemon_request_mailbox = Mailbox[str, RowList](
+            do_send_msg=self._send_daemon_request
+        )
 
     async def serve_forever(self):
         await self._run_setup()
@@ -305,36 +317,24 @@ class BradFrontEnd(BradInterface):
         """
         command = command_raw.upper()
 
-        if command == "BRAD_SYNC":
-            logger.debug("Manually triggered a data sync.")
-            ran_sync = await self._data_sync_executor.run_sync(
-                self._blueprint_mgr.get_blueprint()
-            )
-            if ran_sync:
-                return [("Sync succeeded.",)]
-            else:
-                return [("Sync skipped. No new writes to sync.",)]
+        if (
+            command == "BRAD_SYNC"
+            or command == "BRAD_EXPLAIN_SYNC_STATIC"
+            or command == "BRAD_EXPLAIN_SYNC"
+        ):
+            if self._daemon_request_mailbox.is_active():
+                return [
+                    (
+                        "Another internal command is pending. "
+                        "Please wait for it to complete first.",
+                    )
+                ]
 
-        elif command == "BRAD_EXPLAIN_SYNC_STATIC":
-            logical_plan = self._data_sync_executor.get_static_logical_plan(
-                self._blueprint_mgr.get_blueprint()
-            )
-            to_return: RowList = [("Logical Data Sync Plan:",)]
-            for str_op in logical_plan.traverse_plan_sequentially():
-                to_return.append((str_op,))
-            return to_return
+            if command == "BRAD_SYNC":
+                logger.debug("Manually requested a data sync.")
 
-        elif command == "BRAD_EXPLAIN_SYNC":
-            logical, physical = await self._data_sync_executor.get_processed_plans(
-                self._blueprint_mgr.get_blueprint()
-            )
-            to_return = [("Logical Data Sync Plan:",)]
-            for str_op in logical.traverse_plan_sequentially():
-                to_return.append((str_op,))
-            to_return.append(("Physical Data Sync Plan:",))
-            for str_op in physical.traverse_plan_sequentially():
-                to_return.append((str_op,))
-            return to_return
+            # Send the command to the daemon for execution.
+            return await self._daemon_request_mailbox.send_recv(command)
 
         else:
             return [("Unknown internal command: {}".format(command),)]
@@ -349,6 +349,21 @@ class BradFrontEnd(BradInterface):
                 logger.debug("The BRAD front end is initiating a shut down...")
                 loop.create_task(_orchestrate_shutdown())
                 break
+            elif isinstance(message, InternalCommandResponse):
+                if message.fe_index != self._fe_index:
+                    logger.warning(
+                        "Received message with invalid front end index. Expected %d. Received %d.",
+                        self._fe_index,
+                        message.fe_index,
+                    )
+                    continue
+                if not self._daemon_request_mailbox.is_active():
+                    logger.warning(
+                        "Received an internal command response but no one was waiting for it: %s",
+                        message,
+                    )
+                    continue
+                self._daemon_request_mailbox.on_new_message(message.response)
             else:
                 logger.info("Received message from the daemon: %s", message)
 
@@ -379,6 +394,12 @@ class BradFrontEnd(BradInterface):
         if sql.endswith(";"):
             sql = sql[:-1]
         return sql.strip()
+
+    async def _send_daemon_request(self, request: str) -> None:
+        message = InternalCommandRequest(self._fe_index, request)
+        logger.debug("Sending internal command request: %s", message)
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._output_queue.put, message)
 
 
 async def _orchestrate_shutdown() -> None:

--- a/src/brad/front_end/grpc.py
+++ b/src/brad/front_end/grpc.py
@@ -53,12 +53,10 @@ class BradGrpc(rpc.BradServicer):
             result = await self._brad.run_query_json(
                 session_id, request.query, debug_info
             )
-            return b.RunQueryJsonResponse(
-                results=b.QueryJsonResponse(
-                    results_json=result,
-                    executor=self._convert_engine(debug_info["executor"]),
-                )
-            )
+            response = b.QueryJsonResponse(results_json=result)
+            if "executor" in debug_info:
+                response.executor = self._convert_engine(debug_info["executor"])
+            return b.RunQueryJsonResponse(results=response)
 
         except QueryError as ex:
             return b.RunQueryJsonResponse(error=b.QueryError(error_msg=str(ex)))

--- a/src/brad/row_list.py
+++ b/src/brad/row_list.py
@@ -1,0 +1,4 @@
+from typing import Any, List, Tuple
+
+
+RowList = List[Tuple[Any, ...]]

--- a/src/brad/utils/mailbox.py
+++ b/src/brad/utils/mailbox.py
@@ -1,0 +1,43 @@
+import asyncio
+from typing import Awaitable, Callable, Generic, TypeVar, Optional
+
+S = TypeVar("S")
+R = TypeVar("R")
+
+
+class Mailbox(Generic[S, R]):
+    """
+    A utility class used to manage asynchronous request-response use cases.
+    """
+
+    def __init__(self, do_send_msg: Callable[[S], Awaitable[None]]) -> None:
+        self._do_send_msg = do_send_msg
+        self._event = asyncio.Event()
+        self._inbox: Optional[R] = None
+        self._is_active = False
+
+    def is_active(self) -> bool:
+        return self._is_active
+
+    async def send_recv(self, msg: S) -> R:
+        try:
+            self._is_active = True
+            await self._send(msg)
+            response = await self._recv()
+            self._inbox = None
+            return response
+        finally:
+            self._is_active = False
+
+    async def _send(self, msg: S) -> None:
+        self._event.clear()
+        await self._do_send_msg(msg)
+
+    async def _recv(self) -> R:
+        await self._event.wait()
+        assert self._inbox is not None
+        return self._inbox
+
+    def on_new_message(self, msg: R) -> None:
+        self._inbox = msg
+        self._event.set()


### PR DESCRIPTION
This PR resolves #84 and resolves #86. We move the data sync executor into the daemon (where it belongs) and add some logic to allow clients to invoke `BRAD_` commands that should run on the daemon (e.g., data syncs).