### PR TITLE
Avoid using an empty workload; provide workloads at planning time

### DIFF
--- a/src/brad/admin/run_planner.py
+++ b/src/brad/admin/run_planner.py
@@ -223,7 +223,6 @@ def run_planner(args) -> None:
 
     planner = BlueprintPlannerFactory.create(
         current_blueprint=blueprint_mgr.get_blueprint(),
-        current_workload=workload,
         planner_config=planner_config,
         monitor=monitor,
         config=config,

--- a/src/brad/planner/abstract.py
+++ b/src/brad/planner/abstract.py
@@ -10,7 +10,6 @@ from brad.planner.estimator import EstimatorProvider
 from brad.planner.metrics import MetricsProvider
 from brad.planner.scoring.data_access.provider import DataAccessProvider
 from brad.planner.scoring.performance.analytics_latency import AnalyticsLatencyScorer
-from brad.planner.workload import Workload
 from brad.planner.workload.provider import WorkloadProvider
 
 NewBlueprintCallback = Callable[[Blueprint], Coroutine[None, None, None]]
@@ -27,7 +26,6 @@ class BlueprintPlanner:
         self,
         planner_config: PlannerConfig,
         current_blueprint: Blueprint,
-        current_workload: Workload,
         monitor: Monitor,
         config: ConfigFile,
         schema_name: str,
@@ -40,7 +38,6 @@ class BlueprintPlanner:
     ) -> None:
         self._planner_config = planner_config
         self._current_blueprint = current_blueprint
-        self._current_workload = current_workload
         self._monitor = monitor
         self._config = config
         self._schema_name = schema_name

--- a/src/brad/planner/beam/query_based.py
+++ b/src/brad/planner/beam/query_based.py
@@ -43,13 +43,13 @@ class QueryBasedBeamPlanner(BlueprintPlanner):
 
         # 1. Fetch the next workload and apply predictions.
         metrics, metrics_timestamp = self._metrics_provider.get_metrics()
-        next_workload = self._workload_provider.next_workload(
+        current_workload, next_workload = self._workload_provider.get_workloads(
             metrics_timestamp, window_multiplier, desired_period=timedelta(hours=1)
         )
         self._analytics_latency_scorer.apply_predicted_latencies(next_workload)
-        self._analytics_latency_scorer.apply_predicted_latencies(self._current_workload)
+        self._analytics_latency_scorer.apply_predicted_latencies(current_workload)
         self._data_access_provider.apply_access_statistics(next_workload)
-        self._data_access_provider.apply_access_statistics(self._current_workload)
+        self._data_access_provider.apply_access_statistics(current_workload)
 
         # 2. Compute query gains and reorder queries by their gain in descending
         # order.
@@ -73,7 +73,7 @@ class QueryBasedBeamPlanner(BlueprintPlanner):
         ctx = ScoringContext(
             self._schema_name,
             self._current_blueprint,
-            self._current_workload,
+            current_workload,
             next_workload,
             metrics,
             self._planner_config,
@@ -307,7 +307,6 @@ class QueryBasedBeamPlanner(BlueprintPlanner):
         # 9. Output the new blueprint.
         best_blueprint = best_candidate.to_blueprint()
         self._current_blueprint = best_blueprint
-        self._current_workload = next_workload
 
         logger.info("Selected blueprint:")
         logger.info("%s", best_blueprint)

--- a/src/brad/planner/factory.py
+++ b/src/brad/planner/factory.py
@@ -12,7 +12,6 @@ from brad.planner.metrics import MetricsProvider
 from brad.planner.scoring.data_access.provider import DataAccessProvider
 from brad.planner.scoring.performance.analytics_latency import AnalyticsLatencyScorer
 from brad.planner.strategy import PlanningStrategy
-from brad.planner.workload import Workload
 from brad.planner.workload.provider import WorkloadProvider
 
 
@@ -21,7 +20,6 @@ class BlueprintPlannerFactory:
     def create(
         planner_config: PlannerConfig,
         current_blueprint: Blueprint,
-        current_workload: Workload,
         monitor: Monitor,
         config: ConfigFile,
         schema_name: str,
@@ -39,7 +37,6 @@ class BlueprintPlannerFactory:
         ):
             return NeighborhoodSearchPlanner(
                 current_blueprint=current_blueprint,
-                current_workload=current_workload,
                 planner_config=planner_config,
                 monitor=monitor,
                 config=config,
@@ -55,7 +52,6 @@ class BlueprintPlannerFactory:
         elif strategy == PlanningStrategy.QueryBasedBeam:
             return QueryBasedBeamPlanner(
                 current_blueprint=current_blueprint,
-                current_workload=current_workload,
                 planner_config=planner_config,
                 monitor=monitor,
                 config=config,
@@ -71,7 +67,6 @@ class BlueprintPlannerFactory:
         elif strategy == PlanningStrategy.TableBasedBeam:
             return TableBasedBeamPlanner(
                 current_blueprint=current_blueprint,
-                current_workload=current_workload,
                 planner_config=planner_config,
                 monitor=monitor,
                 config=config,

--- a/src/brad/planner/workload/query.py
+++ b/src/brad/planner/workload/query.py
@@ -17,6 +17,8 @@ class Query(QueryRep):
     """
     A `QueryRep` that is decorated with additional statistics that are used for
     blueprint planning.
+
+    Objects of this class are logically immutable.
     """
 
     def __init__(self, sql_query: str, arrival_count: int = 1):
@@ -94,6 +96,3 @@ class Query(QueryRep):
 
         # MB, so we divide by 1000 twice.
         self._data_accessed_mb[for_engine] = total_storage_bytes // 1000 // 1000
-
-    def clear_stats(self) -> None:
-        self._data_accessed_mb.clear()

--- a/src/brad/planner/workload/workload.py
+++ b/src/brad/planner/workload/workload.py
@@ -89,6 +89,34 @@ class Workload:
         self._table_sizes_mb: Dict[Tuple[str, Engine], int] = {}
         self._dataset_size_mb = 0
 
+    def clone(self) -> "Workload":
+        workload = Workload(
+            self._period,
+            self._analytical_queries.copy(),
+            self._transactional_queries.copy(),
+            self._table_sizes.copy(),
+        )
+
+        if self._predicted_analytical_latencies is not None:
+            workload._predicted_analytical_latencies = (  # pylint: disable=protected-access
+                self._predicted_analytical_latencies.copy()
+            )
+
+        if self._predicted_aurora_pages_accessed is not None:
+            workload._predicted_aurora_pages_accessed = (  # pylint: disable=protected-access
+                self._predicted_aurora_pages_accessed.copy()
+            )
+
+        if self._predicted_athena_bytes_accessed is not None:
+            workload._predicted_athena_bytes_accessed = (  # pylint: disable=protected-access
+                self._predicted_athena_bytes_accessed.copy()
+            )
+
+        # N.B. We do not edit the legacy properties because this method is a new
+        # method and is unused in legacy code.
+
+        return workload
+
     def serialize_for_debugging(self, output_path: str | Path) -> None:
         with open(output_path, "wb") as out_file:
             pickle.dump(self, out_file)

--- a/src/brad/query_rep.py
+++ b/src/brad/query_rep.py
@@ -25,6 +25,8 @@ class QueryRep:
     In practice, this class is used to abstract away the internal representation
     so that its implementation details are not part of the interface of other
     BRAD classes (e.g., we want to avoid exposing the query's parsed representation).
+
+    Objects of this class are logically immutable.
     """
 
     def __init__(self, sql_query: str):


### PR DESCRIPTION
This is a somewhat stopgap approach to prevent using empty workloads at blueprint planning time. Now the `WorkloadProvider` provides both the current workload and next (forecasted) workload. Right now the two are the same.

Ideally the current workload represents the queries seen since the last planning run. The next workload can contain forecasted queries and metadata about the state of the dataset (e.g., size of the tables). Right now it is identical to the current workload.