### PR TITLE
Add a penalty power

### DIFF
--- a/config/system_config.yml
+++ b/config/system_config.yml
@@ -105,6 +105,7 @@ comparator:
     minutes: 0
 
   penalty_threshold: 0.8  # Only used by the `benefit_perf_ceiling` comparator
+  penalty_power: 8  # Only used by the `benefit_perf_ceiling` comparator
 
 # Used for precomputed predictions.
 std_datasets:

--- a/experiments/15-e2e-scenarios-v2/scale_down/scale_down_config.yml
+++ b/experiments/15-e2e-scenarios-v2/scale_down/scale_down_config.yml
@@ -101,6 +101,7 @@ comparator:
     minutes: 0
 
   penalty_threshold: 0.8  # Only used by the `benefit_perf_ceiling` comparator
+  penalty_power: 8  # Only used by the `benefit_perf_ceiling` comparator
 
 # Used for precomputed predictions.
 std_datasets:

--- a/experiments/15-e2e-scenarios-v2/scale_up/scale_up_config.yml
+++ b/experiments/15-e2e-scenarios-v2/scale_up/scale_up_config.yml
@@ -101,6 +101,7 @@ comparator:
     minutes: 0
 
   penalty_threshold: 0.8  # Only used by the `benefit_perf_ceiling` comparator
+  penalty_power: 8  # Only used by the `benefit_perf_ceiling` comparator
 
 # Used for precomputed predictions.
 std_datasets:

--- a/experiments/15-e2e-scenarios-v2/specialized/specialized_config.yml
+++ b/experiments/15-e2e-scenarios-v2/specialized/specialized_config.yml
@@ -101,6 +101,7 @@ comparator:
     minutes: 0
 
   penalty_threshold: 0.8  # Only used by the `benefit_perf_ceiling` comparator
+  penalty_power: 8  # Only used by the `benefit_perf_ceiling` comparator
 
 # Used for precomputed predictions.
 std_datasets:

--- a/src/brad/config/temp_config.py
+++ b/src/brad/config/temp_config.py
@@ -46,6 +46,13 @@ class TempConfig:
     def penalty_threshold(self) -> float:
         return self._raw["comparator"]["penalty_threshold"]
 
+    def penalty_power(self) -> float:
+        comparator_config = self._raw["comparator"]
+        if "penalty_power" in comparator_config:
+            return comparator_config["penalty_power"]
+        else:
+            return 1.0
+
     def std_datasets(self) -> List[Dict[str, str]]:
         if "std_datasets" not in self._raw:
             return []

--- a/src/brad/daemon/daemon.py
+++ b/src/brad/daemon/daemon.py
@@ -196,6 +196,7 @@ class BradDaemon:
                         self._temp_config.txn_latency_p90_ceiling_s(),
                         self._temp_config.benefit_horizon(),
                         self._temp_config.penalty_threshold(),
+                        self._temp_config.penalty_power(),
                     )
                 )
             else:

--- a/src/brad/planner/compare/cost_with_benefit.py
+++ b/src/brad/planner/compare/cost_with_benefit.py
@@ -15,6 +15,7 @@ def best_cost_under_perf_ceilings_with_benefit_horizon(
     curr_hourly_cost: float,
     benefit_horizon: timedelta,
     penalty_threshold: float,
+    penalty_power: float,
 ) -> BlueprintComparator:
     def is_better_than(left: ComparableBlueprint, right: ComparableBlueprint) -> bool:
         # Transactional latency ceilings (feasibility check).
@@ -34,7 +35,7 @@ def best_cost_under_perf_ceilings_with_benefit_horizon(
 
         # We compute a scalar score for each blueprint (lower is better):
         #
-        # Score = Penalty * C_0 * T + C * (B - T)
+        # Score = Penalty^Power * C_0 * T + C * (B - T)
         # Penalty = 1 + max(0, max(curr_query_p90 / max_query_p90, curr_txn_p90 / max_txn_p90) - threshold)
         # Threshold = 0.8 (hyperparameter)
         #
@@ -54,6 +55,7 @@ def best_cost_under_perf_ceilings_with_benefit_horizon(
             curr_txn_p90_latency_s,
             penalty_threshold,
         )
+        penalty_multiplier = math.pow(penalty_multiplier, penalty_power)
 
         left_score = _compute_scalar_score(
             left.get_transition_time_s(),

--- a/src/brad/planner/compare/provider.py
+++ b/src/brad/planner/compare/provider.py
@@ -43,15 +43,22 @@ class BenefitPerformanceCeilingComparatorProvider(BlueprintComparatorProvider):
         max_txn_p90_latency_s: float,
         benefit_horizon: timedelta,
         threshold: float,
+        penalty_power: float,
     ) -> None:
         self._max_query_p90_latency_s = max_query_p90_latency_s
         self._max_txn_p90_latency_s = max_txn_p90_latency_s
         self._benefit_horizon = benefit_horizon
         self._threshold = threshold
+        self._penalty_power = penalty_power
 
     def get_comparator(
         self, metrics: Metrics, curr_hourly_cost: float
     ) -> BlueprintComparator:
+        # To support logged planning runs.
+        if hasattr(self, "_penalty_power"):
+            penalty_power = self._penalty_power
+        else:
+            penalty_power = 1.0
         return best_cost_under_perf_ceilings_with_benefit_horizon(
             max_query_p90_latency_s=self._max_query_p90_latency_s,
             max_txn_p90_latency_s=self._max_txn_p90_latency_s,
@@ -60,4 +67,5 @@ class BenefitPerformanceCeilingComparatorProvider(BlueprintComparatorProvider):
             curr_hourly_cost=curr_hourly_cost,
             benefit_horizon=self._benefit_horizon,
             penalty_threshold=self._threshold,
+            penalty_power=penalty_power,
         )


### PR DESCRIPTION
Part of #296. We need to increase the penalty when the current blueprint is exceeding the performance constraints. Otherwise it will tend to pick blueprints that take longer to transition to because it ends up appearing cheaper.